### PR TITLE
fix: camel case for dns result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Changelog
 
 ## [0.6.0](TODOADDRELEASE) (DATE)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.6.0](TODOADDRELEASE) (DATE)
+
+### Features
+
+* added Changelog file
+
+### Bug Fixes
+
+* **BREAKING CHANGE:** DNS metric returns lowercase keys instead of uppercase ones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Changelog
 
-## [0.6.0](TODOADDRELEASE) (DATE)
+## [v0.6.0](TODOADDRELEASE) (DATE)
+⚠️ This release contains potential breaking change ⚠️
 
-### Features
+The API returns lowercase keys instead of capitalized keys. Ensure that your code handles this change to avoid issues.
 
-* added Changelog file
-
-### Bug Fixes
-
-* **BREAKING CHANGE:** DNS metric returns lowercase keys instead of uppercase ones
+* [ENHANCEMENT] added Changelog file
+* [BUGFIX] DNS metric returns lowercase keys instead of capitalized keys

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ latency:
 
 ### Check: DNS
 > [!CAUTION]
-> Versions > v0.5.0, the api returns lowecase keys instead of uppercase.
+> Versions > v0.5.0, the api returns lowercase keys instead of uppercase.
 
 Available configuration options:
 
@@ -633,7 +633,7 @@ Is roughly equal to this:
 ## API
 
 > [!CAUTION]
-> Versions > v0.5.0, the api returns lowecase keys instead of uppercase for DNS metric.
+> Versions > v0.5.0, the api returns lowercase keys instead of uppercase for DNS metric.
 
 The `sparrow` exposes an API for accessing the results of various checks. Each check registers its own endpoint
 at `/v1/metrics/{check-name}`. The API's definition is available at `/openapi`.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ latency:
   - Labelled with `target`
 
 ### Check: DNS
+> [!CAUTION]
+> Versions > v0.5.0, the api returns lowecase keys instead of uppercase.
 
 Available configuration options:
 
@@ -629,6 +631,9 @@ Is roughly equal to this:
 ```
 
 ## API
+
+> [!CAUTION]
+> Versions > v0.5.0, the api returns lowecase keys instead of uppercase for DNS metric.
 
 The `sparrow` exposes an API for accessing the results of various checks. Each check registers its own endpoint
 at `/v1/metrics/{check-name}`. The API's definition is available at `/openapi`.

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ latency:
 
 ### Check: DNS
 > [!CAUTION]
-> Versions > v0.5.0, the api returns lowercase keys instead of uppercase.
+> **Breaking Change:** Starting from version `v0.6.0`, the API returns lowercase keys instead of capitalized keys. Ensure that your code handles this change to avoid issues. 
 
 Available configuration options:
 
@@ -633,7 +633,7 @@ Is roughly equal to this:
 ## API
 
 > [!CAUTION]
-> Versions > v0.5.0, the api returns lowercase keys instead of uppercase for DNS metric.
+> **Breaking Change:** Starting from version `v0.6.0`, the API returns lowercase keys instead of capitalized keys. Ensure that your code handles this change to avoid issues.
 
 The `sparrow` exposes an API for accessing the results of various checks. Each check registers its own endpoint
 at `/v1/metrics/{check-name}`. The API's definition is available at `/openapi`.

--- a/pkg/checks/dns/dns.go
+++ b/pkg/checks/dns/dns.go
@@ -60,9 +60,9 @@ func NewCheck() checks.Check {
 
 // result represents the result of a single DNS check for a specific target
 type result struct {
-	Resolved []string
-	Error    *string
-	Total    float64
+	Resolved []string `json:"resolved"`
+	Error    *string  `json:"error"`
+	Total    float64  `json:"total"`
 }
 
 // Run starts the dns check


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH

SPDX-License-Identifier: CC-BY-4.0
-->

## Motivation

The DNS check was the only one not fully using camel case in the API response.

## Changes

I added JSON tags to the DNS result struct.

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->