### PR TITLE
refactor: replace slice-based iteration with go 1.23 iterators

### DIFF
--- a/pkg/checks/runtime/checks.go
+++ b/pkg/checks/runtime/checks.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"iter"
 	"slices"
 	"sync"
 
@@ -14,7 +15,7 @@ import (
 // Checks holds all the checks.
 type Checks struct {
 	mu     sync.RWMutex
-	checks []checks.Check
+	checks []checks.Check // = *checks.Check
 }
 
 // Add adds a new check.
@@ -37,8 +38,8 @@ func (c *Checks) Delete(check checks.Check) {
 }
 
 // Iter returns configured checks in an iterable format
-func (c *Checks) Iter() []checks.Check {
+func (c *Checks) Iter() iter.Seq[checks.Check] {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return slices.Clone(c.checks)
+	return slices.Values(slices.Clone(c.checks))
 }

--- a/pkg/checks/runtime/checks.go
+++ b/pkg/checks/runtime/checks.go
@@ -15,7 +15,7 @@ import (
 // Checks holds all the checks.
 type Checks struct {
 	mu     sync.RWMutex
-	checks []checks.Check // = *checks.Check
+	checks []checks.Check
 }
 
 // Add adds a new check.

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -36,7 +36,7 @@ func NewChecksFromConfig(cfg runtime.Config) (map[string]checks.Check, error) {
 	}
 
 	result := make(map[string]checks.Check)
-	for _, c := range cfg.Iter() {
+	for c := range cfg.Iter() {
 		check, err := newCheck(c)
 		if err != nil {
 			return nil, err

--- a/pkg/sparrow/controller.go
+++ b/pkg/sparrow/controller.go
@@ -69,7 +69,7 @@ func (cc *ChecksController) Shutdown(ctx context.Context) {
 	log := logger.FromContext(ctx)
 	log.Info("Shutting down checks controller")
 
-	for _, c := range cc.checks.Iter() {
+	for c := range cc.checks.Iter() {
 		cc.UnregisterCheck(ctx, c)
 	}
 	cc.done <- struct{}{}
@@ -90,7 +90,7 @@ func (cc *ChecksController) Reconcile(ctx context.Context, cfg runtime.Config) {
 
 	// Update existing checks and create a list of checks to unregister
 	var unregList []checks.Check
-	for _, c := range cc.checks.Iter() {
+	for c := range cc.checks.Iter() {
 		conf := cfg.For(c.Name())
 		if conf == nil {
 			unregList = append(unregList, c)
@@ -182,7 +182,7 @@ var oapiBoilerplate = openapi3.T{
 func (cc *ChecksController) GenerateCheckSpecs(ctx context.Context) (openapi3.T, error) {
 	log := logger.FromContext(ctx)
 	doc := oapiBoilerplate
-	for _, c := range cc.checks.Iter() {
+	for c := range cc.checks.Iter() {
 		name := c.Name()
 		ref, err := c.Schema()
 		if err != nil {

--- a/pkg/sparrow/targets/remote/gitlab/pagination.go
+++ b/pkg/sparrow/targets/remote/gitlab/pagination.go
@@ -22,7 +22,7 @@ func getNextLink(header http.Header) string {
 		return ""
 	}
 
-	for _, link := range strings.Split(link, ",") {
+	for link := range strings.SplitSeq(link, ",") {
 		linkParts := strings.Split(link, ";")
 		if len(linkParts) != 2 {
 			continue


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->
This pull request refactors the iteration mechanism throughout the codebase by replacing slice-based iterations with the new iterator feature utilizing the `iter` package. Although benchmark tests (see below) did not show a significant change in performance, the new approach streamlines the code with newly introduced patterns regarding iterators.

## Changes

### Iteration Improvements:

* **Iteration Update:**  
  - Updated the `Iter` methods in [`pkg/checks/runtime/checks.go`](diffhunk://#diff-a5a942aff6e63bf673a3de191b69ebec816ec4347b9985dcc8e447b391bb39bdL40-R44) and [`pkg/checks/runtime/config.go`](diffhunk://#diff-18ac026b1b8a99127b21e4e4c452529beea4191702a250aeace32ebf5c0d1e68L42-L57) to return iterators (using `iter.Seq[...]`) instead of slices.  
  - This change simplifies iteration logic and reduces code clutter.

### Code Refactoring:

* **Factory Update:**  
  - Modified [`pkg/factory/factory.go`](diffhunk://#diff-049554c55ff1bfecd892bda8c893152ea83135948b6c43b36ad02b068a892fcaL39-R39) so that the new iterator is used when processing configuration data.
  
* **Controller Adjustments:**  
  - Updated methods like `Shutdown`, `Reconcile`, and `GenerateCheckSpecs` in [`pkg/sparrow/controller.go`](diffhunk://#diff-c9dbbf2ce9559b49264891840f686d25cb1585c7869bcee3a3dcf9bf12f98564L72-R72) to work with the new `iter.Seq`.
  
### Additional Changes:

* **Remote GitLab Target:**  
  - Improved [`pkg/sparrow/targets/remote/gitlab/pagination.go`](diffhunk://#diff-9369f212b9726e43f3a845172a2db46f832290655587a2047dc275d1d7eb0a87L25-R25) by using `strings.SplitSeq` for more efficient string splitting.

### Commits

* [refactor: update Iter methods to return iterators for improved performance](https://github.com/telekom/sparrow/commit/557c7fbfc01ed548e59aa643300156cb87cd082c) 

This commit refactors the 'Iter' methods to return iterators instead of complete slices. We utilize the newly introduced 'iter' standard library package to achieve this. This change improves the performance of the 'Iter' methods by reducing the number of allocations and copying operations.

Signed-off-by: lvlcn-t <75443136+lvlcn-t@users.noreply.github.com>

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->
I've added a benchmark test to be able to better see if there is any performance gained. You can find the test results below.

- [x] Unit tests succeeded
- [ ] ~E2E tests succeeded~ - We have none for this (#222 will add them)

### Benchmark Results

The new benchmark test for the `Reconcile` function shows nearly identical results before and after the changes:

- **Before:**  
  ~1,002,994,868 ns/op, 102,224 B/op, 1,315 allocs/op

- **After:**  
  ~1,003,090,300 ns/op, 102,776 B/op, 1,320 allocs/op

These results confirm that while the refactoring does not significantly change the performance characteristics, it improves the code structure by using new language features.

<details>
<summary>Before</summary>

```shell
go test -benchmem -run=^$ -bench ^BenchmarkReconcile$ github.com/telekom/sparrow/pkg/sparrow -race -cover -count=1

{"time":"2025-03-23T19:16:31.855068339+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).Run","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":62},"msg":"Starting healthcheck","interval":"1s"}
{"time":"2025-03-23T19:16:31.855257319+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).Run","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":64},"msg":"Starting latency check","interval":"1s"}
{"time":"2025-03-23T19:16:31.855346099+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).Run","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":74},"msg":"Starting dns check","interval":"1s"}
goos: linux
goarch: amd64
pkg: github.com/telekom/sparrow/pkg/sparrow
cpu: AMD Ryzen 7 5700X3D 8-Core Processor           
BenchmarkReconcile-16    	{"time":"2025-03-23T19:16:32.8566561+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.getHealth","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":213},"msg":"Error while requesting health","url":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
       1	1002994868 ns/op	  102224 B/op	    1315 allocs/op
{"time":"2025-03-23T19:16:32.85666629+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.getLatency","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":224},"msg":"Error while checking latency","url":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
--- BENCH: BenchmarkReconcile-16
    controller_test.go:555: Run called for check mockCheck0
    controller_test.go:555: Run called for check mockCheck1
    controller_test.go:555: Run called for check mockCheck2
    controller_test.go:555: Run called for check mockCheck3
    controller_test.go:555: Run called for check mockCheck4
    controller_test.go:555: Run called for check mockCheck5
    controller_test.go:555: Run called for check mockCheck6
    controller_test.go:555: Run called for check mockCheck7
    controller_test.go:555: Run called for check mockCheck8
    controller_test.go:555: Run called for check mockCheck11
	... [output truncated]
PASS
{"time":"2025-03-23T19:16:32.856711708+01:00","level":"WARN","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":182},"msg":"Health check failed after 0 retries","target":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:16:32.85673268+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":188},"msg":"Error while checking latency","target":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:16:32.856946414+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).Run","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":66},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:16:32.856996865+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).Run","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":68},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:16:32.857020004+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"health","error":"context canceled"}
{"time":"2025-03-23T19:16:32.857037246+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"latency","error":"context canceled"}
{"time":"2025-03-23T19:16:32.8577985+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.getDNS","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":219},"msg":"Error while looking up address","address":"telekom.com","error":"lookup telekom.com on 10.255.255.254:53: dial udp 10.255.255.254:53: operation was canceled"}
{"time":"2025-03-23T19:16:32.857861896+01:00","level":"WARN","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":185},"msg":"Error while looking up address","target":"telekom.com","error":"lookup telekom.com on 10.255.255.254:53: dial udp 10.255.255.254:53: operation was canceled"}
coverage: 14.5% of statements
{"time":"2025-03-23T19:16:32.857963395+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).Run","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":78},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:16:32.858049466+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"dns","error":"context canceled"}
ok  	github.com/telekom/sparrow/pkg/sparrow	2.024s
```

</details>

<details>
<summary>After</summary>

```shell
go test -benchmem -run=^$ -bench ^BenchmarkReconcile$ github.com/telekom/sparrow/pkg/sparrow -race -cover -count=1

{"time":"2025-03-23T19:17:07.842020443+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).Run","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":62},"msg":"Starting healthcheck","interval":"1s"}
{"time":"2025-03-23T19:17:07.84206065+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).Run","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":74},"msg":"Starting dns check","interval":"1s"}
{"time":"2025-03-23T19:17:07.842053546+01:00","level":"INFO","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).Run","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":64},"msg":"Starting latency check","interval":"1s"}
goos: linux
goarch: amd64
pkg: github.com/telekom/sparrow/pkg/sparrow
cpu: AMD Ryzen 7 5700X3D 8-Core Processor           
BenchmarkReconcile-16    	       1	1003090300 ns/op	  102776 B/op	    1320 allocs/op
--- BENCH: BenchmarkReconcile-16
    controller_test.go:557: Run called for check mockCheck0
    controller_test.go:557: Run called for check mockCheck1
    controller_test.go:557: Run called for check mockCheck2
    controller_test.go:557: Run called for check mockCheck3
    controller_test.go:557: Run called for check mockCheck4
    controller_test.go:557: Run called for check mockCheck5
    controller_test.go:557: Run called for check mockCheck6
    controller_test.go:557: Run called for check mockCheck7
    controller_test.go:557: Run called for check mockCheck8
    controller_test.go:557: Run called for check mockCheck9
	... [output truncated]
PASS
{"time":"2025-03-23T19:17:08.843570608+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.getHealth","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":213},"msg":"Error while requesting health","url":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:17:08.843795225+01:00","level":"WARN","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":182},"msg":"Health check failed after 0 retries","target":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:17:08.84376923+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.getLatency","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":224},"msg":"Error while checking latency","url":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:17:08.843923275+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/health.(*Health).Run","file":"/home/tom/dev/sparrow/pkg/checks/health/health.go","line":66},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:17:08.843934585+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":188},"msg":"Error while checking latency","target":"https://telekom.com","error":"Get \"https://telekom.com\": context canceled"}
{"time":"2025-03-23T19:17:08.843962444+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"health","error":"context canceled"}
{"time":"2025-03-23T19:17:08.844109729+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/latency.(*Latency).Run","file":"/home/tom/dev/sparrow/pkg/checks/latency/latency.go","line":68},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:17:08.844177193+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"latency","error":"context canceled"}
{"time":"2025-03-23T19:17:08.844500632+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.getDNS","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":219},"msg":"Error while looking up address","address":"telekom.com","error":"lookup telekom.com on 10.255.255.254:53: dial udp 10.255.255.254:53: operation was canceled"}
{"time":"2025-03-23T19:17:08.844567857+01:00","level":"WARN","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).check.func2","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":185},"msg":"Error while looking up address","target":"telekom.com","error":"lookup telekom.com on 10.255.255.254:53: dial udp 10.255.255.254:53: operation was canceled"}
{"time":"2025-03-23T19:17:08.844671836+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/checks/dns.(*DNS).Run","file":"/home/tom/dev/sparrow/pkg/checks/dns/dns.go","line":78},"msg":"Context canceled","err":"context canceled"}
{"time":"2025-03-23T19:17:08.844729455+01:00","level":"ERROR","source":{"function":"github.com/telekom/sparrow/pkg/sparrow.(*ChecksController).RegisterCheck.func1","file":"/home/tom/dev/sparrow/pkg/sparrow/controller.go","line":132},"msg":"Failed to run check","check":"dns","error":"context canceled"}
coverage: 14.5% of statements
ok  	github.com/telekom/sparrow/pkg/sparrow	2.027s
```

</details>

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->