### PR TITLE
refactor(checks): move global target merging responsibility to checks

### DIFF
--- a/pkg/checks/latency/config.go
+++ b/pkg/checks/latency/config.go
@@ -5,11 +5,14 @@
 package latency
 
 import (
+	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/telekom/sparrow/internal/helper"
+	"github.com/telekom/sparrow/internal/logger"
 	"github.com/telekom/sparrow/pkg/checks"
 )
 
@@ -53,4 +56,22 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// Enrich adds the global targets to the configuration
+func (c *Config) Enrich(ctx context.Context, targets []checks.GlobalTarget) {
+	log := logger.FromContext(ctx)
+	for _, t := range targets {
+		u, err := t.URL()
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get URL from target", "target", t, "error", err)
+			continue
+		}
+
+		target := u.String()
+		if !slices.Contains(c.Targets, target) {
+			log.DebugContext(ctx, "Adding target to health check", "target", target)
+			c.Targets = append(c.Targets, target)
+		}
+	}
 }

--- a/pkg/checks/runtime/config.go
+++ b/pkg/checks/runtime/config.go
@@ -5,8 +5,10 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 
+	"github.com/telekom/sparrow/internal/logger"
 	"github.com/telekom/sparrow/pkg/checks"
 	"github.com/telekom/sparrow/pkg/checks/dns"
 	"github.com/telekom/sparrow/pkg/checks/health"
@@ -55,6 +57,16 @@ func (c Config) Iter() []checks.Runtime {
 		configs = append(configs, c.Traceroute)
 	}
 	return configs
+}
+
+// Enrich enriches the configuration with the provided [GlobalTarget]s.
+func (c Config) Enrich(ctx context.Context, targets []checks.GlobalTarget) Config {
+	l := logger.FromContext(ctx)
+	for _, cfg := range c.Iter() {
+		l.DebugContext(ctx, "Enriching check configuration", "check", cfg.For())
+		cfg.Enrich(ctx, targets)
+	}
+	return c
 }
 
 // size returns the number of checks configured

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/telekom/sparrow/pkg/checks/health"
 	"github.com/telekom/sparrow/pkg/checks/latency"
 	"github.com/telekom/sparrow/pkg/checks/runtime"
+	"github.com/telekom/sparrow/pkg/checks/traceroute"
 	"github.com/telekom/sparrow/pkg/config"
 	"github.com/telekom/sparrow/pkg/sparrow/targets"
 	"github.com/telekom/sparrow/pkg/sparrow/targets/interactor"
@@ -43,7 +44,7 @@ func TestSparrow_Run_FullComponentStart(t *testing.T) {
 			},
 			Config: interactor.Config{
 				Gitlab: gitlab.Config{
-					BaseURL:   "https://gitlab.com",
+					BaseURL:   "https://telekom.com",
 					Token:     "my-cool-token",
 					ProjectID: 42,
 				},
@@ -163,19 +164,19 @@ func TestSparrow_enrichTargets(t *testing.T) {
 			name: "config with targets (health + latency)",
 			config: runtime.Config{
 				Health: &health.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets: []string{"https://telekom.com"},
 				},
 				Latency: &latency.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets: []string{"https://telekom.com"},
 				},
 			},
 			globalTargets: gt,
 			expected: runtime.Config{
 				Health: &health.Config{
-					Targets: []string{"https://gitlab.com", testTarget},
+					Targets: []string{"https://telekom.com", testTarget},
 				},
 				Latency: &latency.Config{
-					Targets: []string{"https://gitlab.com", testTarget},
+					Targets: []string{"https://telekom.com", testTarget},
 				},
 			},
 		},
@@ -183,13 +184,32 @@ func TestSparrow_enrichTargets(t *testing.T) {
 			name: "config with targets (dns)",
 			config: runtime.Config{
 				Dns: &dns.Config{
-					Targets: []string{"gitlab.com"},
+					Targets: []string{"telekom.com"},
 				},
 			},
 			globalTargets: gt,
 			expected: runtime.Config{
 				Dns: &dns.Config{
-					Targets: []string{"gitlab.com", "localhost.de"},
+					Targets: []string{"telekom.com", "localhost.de"},
+				},
+			},
+		},
+		{
+			name: "config with targets (traceroute)",
+			config: runtime.Config{
+				Traceroute: &traceroute.Config{
+					Targets: []traceroute.Target{
+						{Addr: "telekom.com", Port: 443},
+					},
+				},
+			},
+			globalTargets: gt,
+			expected: runtime.Config{
+				Traceroute: &traceroute.Config{
+					Targets: []traceroute.Target{
+						{Addr: "telekom.com", Port: 443},
+						{Addr: "localhost.de", Port: 443},
+					},
 				},
 			},
 		},
@@ -215,7 +235,7 @@ func TestSparrow_enrichTargets(t *testing.T) {
 				},
 			},
 			globalTargets: append(gt, checks.GlobalTarget{
-				Url:      "https://sparrow.com",
+				Url:      "https://sparrow.telekom.com",
 				LastSeen: now,
 			}),
 			expected: runtime.Config{
@@ -233,16 +253,16 @@ func TestSparrow_enrichTargets(t *testing.T) {
 			},
 			globalTargets: []checks.GlobalTarget{
 				{
-					Url:      "http://az1.sparrow.com",
+					Url:      "http://az1.sparrow.telekom.com",
 					LastSeen: now,
 				},
 				{
-					Url: "https://az2.sparrow.com",
+					Url: "https://az2.sparrow.telekom.com",
 				},
 			},
 			expected: runtime.Config{
 				Dns: &dns.Config{
-					Targets: []string{"az1.sparrow.com", "az2.sparrow.com"},
+					Targets: []string{"az1.sparrow.telekom.com", "az2.sparrow.telekom.com"},
 				},
 			},
 		},
@@ -255,7 +275,7 @@ func TestSparrow_enrichTargets(t *testing.T) {
 					Targets: tt.globalTargets,
 				},
 				config: &config.Config{
-					SparrowName: "sparrow.com",
+					SparrowName: "sparrow.telekom.com",
 				},
 			}
 			got := s.enrichTargets(context.Background(), tt.config)


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->
Closes #100 

I've also added global target merging for the traceroute check, as we didn't enrich the targets yet.

## Changes

* [refactor(checks): move global target merging responsibility to checks](https://github.com/telekom/sparrow/commit/a3e6d4a6955bc8b0ff14e72e32e4da3839bb1e7b) 

This commit moves the responsibility of merging global targets with the configured targets to each check. This way the checks can decide how to merge the global targets with the configured targets.

Signed-off-by: lvlcn-t <75443136+lvlcn-t@users.noreply.github.com>

<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

I've added an additional test case for the traceroute enrichment.

- [x] Unit tests succeeded
- [ ] ~E2E tests succeeded~ - we have none for this

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->